### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ Push Extension to Shopify
 ```bash
 shopify extension push
 ```
+
+### Resources
+
+[Shopify UI Extensions](https://github.com/Shopify/ui-extensions)

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "typescript": "^3.0.0"
   },
   "scripts": {
-    "argo-server": "argo-admin-cli server --entry=\"src/index.tsx\" --port=39351 --type=PRODUCT_SUBSCRIPTION",
-    "argo-build": "argo-admin-cli build --entry=\"src/index.tsx\"",
     "server": "admin-ui-extensions-run server --entry=\"src/index.tsx\" --port=39351 --type=PRODUCT_SUBSCRIPTION",
     "build": "admin-ui-extensions-run build --entry=\"src/index.tsx\""
   },

--- a/src/components/actions.tsx
+++ b/src/components/actions.tsx
@@ -5,7 +5,6 @@ function Actions({ onPrimary, onClose, title }) {
   return (
     <BlockStack spacing="none" inlineAlignment="center">
       <Button title="Cancel" onPress={onClose} />
-      Block
       <BlockStack inlineAlignment="center" spacing="loose">
         <Button title={title} onPress={onPrimary} />
       </BlockStack>

--- a/src/components/createv2.tsx
+++ b/src/components/createv2.tsx
@@ -33,14 +33,11 @@ function Create() {
   // Mock plan settings
   const [error, setError] = useState<boolean>(false);
   const [planGroupName, setPlanGroupName] = useState<string>('');
-  const [percentageOff, setPercentageOff] = useState<string>('5');
   const [merchantCode, setMerchantCode] = useState<string>('');
   const [planGroupOption, setPlanGroupOption] = useState<string>('');
   const [planGroupDescription, setPlanGroupDescription] = useState<string>('');
   const [numberOfPlans, setNumberOfPlans] = useState<string>('1');
-  const [sellingPlansInput, setSellingPlansInput] = useState<{
-    [key: number]: SellingPlan;
-  }>({});
+
   let sellingPlanInitialState: { [key: number]: SellingPlan } = {};
   for (let i = 1; i <= 10; i++) {
     sellingPlanInitialState[i] = {
@@ -48,12 +45,9 @@ function Create() {
       intervalCount: '1',
       intervalOption: 'MONTH',
       percentageOff: '5',
-      planName: '',
     };
   }
-  // const [sellingPlans, setSellingPlans] = useState<{
-  //   [key: number]: SellingPlan;
-  // }>(sellingPlanInitialState);
+
   const [sellingPlans, setSellingPlans] = useState<any>(
     sellingPlanInitialState
   );
@@ -160,7 +154,7 @@ function Create() {
         </Text>
       )}
 
-      <Card title="Create a Subscription Plan Group" sectioned>
+      <Card title="Subscription Plan Group" sectioned>
         <TextField
           label="Group Name"
           value={planGroupName}

--- a/src/components/sellingPlanForm.tsx
+++ b/src/components/sellingPlanForm.tsx
@@ -5,29 +5,12 @@ import {
   Text,
   Select,
   BlockStack,
-  useData,
-  useContainer,
-  useLocale,
-  useSessionToken,
 } from '@shopify/admin-ui-extensions-react';
-import { Translations, translations } from './config';
 
 function SellingPlanForm({ index, handleSellingPlans }) {
-  const [planName, setPlanName] = useState<string>('');
   const [intervalOption, setIntervalOption] = useState<string>('MONTH');
   const [intervalCount, setIntervalCount] = useState<string>('1');
   const [percentageOff, setPercentageOff] = useState<string>('5');
-
-  const handlePlanName = (name: string) => {
-    setPlanName(name);
-    handleSellingPlans(index, {
-      id: index,
-      intervalCount,
-      intervalOption,
-      percentageOff,
-      planName: name,
-    });
-  };
 
   const handleIntervalCount = (count: string) => {
     setIntervalCount(count);
@@ -36,7 +19,6 @@ function SellingPlanForm({ index, handleSellingPlans }) {
       intervalCount: count,
       intervalOption,
       percentageOff,
-      planName,
     });
   };
 
@@ -47,7 +29,6 @@ function SellingPlanForm({ index, handleSellingPlans }) {
       intervalCount,
       intervalOption: interval,
       percentageOff,
-      planName,
     });
   };
 
@@ -58,17 +39,15 @@ function SellingPlanForm({ index, handleSellingPlans }) {
       intervalCount,
       intervalOption,
       percentageOff: percent,
-      planName,
     });
   };
 
   return (
     <CardSection title={`Selling Plan ${index}`}>
-      <TextField
-        label="Plan Name"
-        value={planName}
-        onChange={value => handlePlanName(value)}
-      />
+      <Text size="small" emphasized appearance="subdued">
+        The selling plan name will automatically be generated based on interval,
+        interval count and discount percentage.
+      </Text>
       <BlockStack>
         <Select
           label="Interval"

--- a/src/types/sellingplans.d.ts
+++ b/src/types/sellingplans.d.ts
@@ -10,6 +10,5 @@ export interface SellingPlan {
   intervalCount: string;
   intervalOption: string;
   percentageOff: string;
-  planName: string;
   position?: number;
 }


### PR DESCRIPTION
Updated create selling plan group view to create selling plans with independent interval, interval option and discount. The selling plan name will still be generated based on interval, interval option and discount. If the plan name needs to be changed / updated this can be done by accessing the selling plan group in the subscription app admin page. The selling plan name as well as interval, interval option and discount can be updated there.